### PR TITLE
feat(core): update puppeteer-core

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@koishijs/canvas": "^0.1.1",
-    "puppeteer-core": "^21.7.0",
+    "puppeteer-core": "^22.2.0",
     "puppeteer-finder": "^1.1.0"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@koishijs/canvas": "^0.1.1",
-    "puppeteer-core": "^19.11.1",
+    "puppeteer-core": "^21.7.0",
     "puppeteer-finder": "^1.1.0"
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,11 +23,6 @@ declare module 'puppeteer-core/lib/types' {
     encoding?: 'binary'
   }
 
-  interface Shooter {
-    screenshot(options?: Base64ScreenshotOptions): Promise<string>
-    screenshot(options?: BinaryScreenshotOptions): Promise<Buffer>
-  }
-
   interface Page {
     screenshot(options?: Base64ScreenshotOptions): Promise<string>
     screenshot(options?: BinaryScreenshotOptions): Promise<Buffer>


### PR DESCRIPTION
已真机测试（plugin-imagify 渲染图片）

此 PR 能消除以下 Warning
```
Puppeteer old Headless deprecation warning:
    In the near feature `headless: true` will default to the new Headless mode
    for Chrome instead of the old Headless implementation. For more
    information, please see https://developer.chrome.com/articles/new-headless/.
    Consider opting in early by passing `headless: "new"` to `puppeteer.launch()`
    If you encounter any bugs, please report them to https://github.com/puppeteer/puppeteer/issues/new/choose.
```

ChangeLog:
puppeteer-core v20.0.0: https://github.com/puppeteer/puppeteer/releases/tag/puppeteer-core-v20.0.0
puppeteer-core v21.0.0: https://github.com/puppeteer/puppeteer/releases/tag/puppeteer-core-v21.0.0